### PR TITLE
Fix broken documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Or using pip:
 
 ### Documentation
 
-A more detailed usage documentation can be found at https://snajder-r.github.io/pycoMeth/
+A more detailed usage documentation can be found at https://pmbio.github.io/pycoMeth/
 
 ### pycoMeth workflow
 


### PR DESCRIPTION
As noted in issue https://github.com/PMBio/pycoMeth/issues/2

Noticed it was correct in the sidebar but not in the README